### PR TITLE
Add ByteString to Calcite's Java-to-SQL Type Mappings

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/JavaToSqlTypeConversionRules.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql.type;
 
 import org.apache.calcite.avatica.util.ArrayImpl;
+import org.apache.calcite.avatica.util.ByteString;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -62,6 +63,7 @@ public class JavaToSqlTypeConversionRules {
           .put(boolean.class, SqlTypeName.BOOLEAN)
           .put(Boolean.class, SqlTypeName.BOOLEAN)
           .put(byte[].class, SqlTypeName.VARBINARY)
+          .put(ByteString.class, SqlTypeName.VARBINARY)
           .put(String.class, SqlTypeName.VARCHAR)
           .put(char[].class, SqlTypeName.VARCHAR)
           .put(Character.class, SqlTypeName.CHAR)

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeUtilTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.sql.type;
 
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
@@ -292,5 +293,11 @@ class SqlTypeUtilTest {
         String.format(Locale.ROOT,
             "Expected to be able to cast from %s to %s without coercion.", fromType, toType),
         SqlTypeUtil.canCastFrom(toType, fromType, /* coerce= */ defaultRules), is(true));
+  }
+
+  @Test void testJavaToSqlByteStringMapping() {
+    SqlTypeName sqlTypeName = JavaToSqlTypeConversionRules.instance().lookup(ByteString.class);
+    assertThat("ByteString.class should map to SqlTypeName.VARBINARY",
+        sqlTypeName, is(SqlTypeName.VARBINARY));
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -182,6 +182,12 @@ class UdfTest {
         + Smalls.AllTypesFunction.class.getName()
         + "',\n"
         + "           methodName: '*'\n"
+        + "         },\n"
+        + "         {\n"
+        + "           name: 'UNBASE64',\n"
+        + "           className: '"
+        + Smalls.MyUnbase64Function.class.getName()
+        + "'\n"
         + "         }\n"
         + "       ]\n"
         + "     }\n"
@@ -1073,6 +1079,22 @@ class UdfTest {
         assertThat(CalciteAssert.toString(resultSet), is(result));
       }
     }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7073">[CALCITE-7073]
+   * Tests that the UNBASE64 user-defined function correctly decodes a Base64 string
+   * and its return type (VARBINARY, mapped from ByteString) is fully
+   * compatible for direct comparison with SQL VARBINARY literals (X'...')
+   * within queries. */
+  @Test
+  void testUnbase64DirectComparison() {
+    final String testHex = "74657374"; // "test" in bytes
+    final String testBase64 = "dGVzdA=="; // Base64 for "test"
+
+    final String sql = "select \"adhoc\".unbase64(cast('" + testBase64 + "' as varchar)) = x'" + testHex + "' as C\n";
+
+    withUdf().query(sql).returns("C=true\n");
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -1082,7 +1082,7 @@ class UdfTest {
   }
 
   /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-7073">[CALCITE-7073]
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7073">[CALCITE-7073] </a>
    * Tests that the UNBASE64 user-defined function correctly decodes a Base64 string
    * and its return type (VARBINARY, mapped from ByteString) is fully
    * compatible for direct comparison with SQL VARBINARY literals (X'...')
@@ -1091,7 +1091,8 @@ class UdfTest {
     final String testHex = "74657374"; // "test" in bytes
     final String testBase64 = "dGVzdA=="; // Base64 for "test"
 
-    final String sql = "select \"adhoc\".unbase64(cast('" + testBase64 + "' as varchar)) = x'" + testHex + "' as C\n";
+    final String sql = "select \"adhoc\".unbase64(cast('" + testBase64 + "' as varchar))"
+        + " = x'" + testHex + "' as C\n";
 
     withUdf().query(sql).returns("C=true\n");
   }

--- a/core/src/test/java/org/apache/calcite/test/UdfTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdfTest.java
@@ -1087,8 +1087,7 @@ class UdfTest {
    * and its return type (VARBINARY, mapped from ByteString) is fully
    * compatible for direct comparison with SQL VARBINARY literals (X'...')
    * within queries. */
-  @Test
-  void testUnbase64DirectComparison() {
+  @Test void testUnbase64DirectComparison() {
     final String testHex = "74657374"; // "test" in bytes
     final String testBase64 = "dGVzdA=="; // Base64 for "test"
 

--- a/testkit/src/main/java/org/apache/calcite/util/Smalls.java
+++ b/testkit/src/main/java/org/apache/calcite/util/Smalls.java
@@ -19,6 +19,7 @@ package org.apache.calcite.util;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.BaseQueryable;
@@ -1475,6 +1476,20 @@ public class Smalls {
               Expressions.constant(tableName));
       return Expressions.call(queryableExpression,
           BuiltInMethod.QUERYABLE_AS_ENUMERABLE.method);
+    }
+  }
+
+  /** User-defined function that decodes a Base64 string to bytes. */
+  public static class MyUnbase64Function {
+    public static ByteString eval(String s) {
+      if (s == null) {
+        return null;
+      }
+      try {
+        return ByteString.ofBase64(s);
+      } catch (Exception e) {
+        return null;
+      }
     }
   }
 }


### PR DESCRIPTION
Calcite uses `org.apache.calcite.avatica.util.ByteString` internally to represent `VARBINARY`. However, when introducing a custom function that returns ByteString, such as `UNBASE64` (which decodes a Base64 string to bytes), its return type defaults to `OTHER`. This occurs because there is no explicit mapping for `ByteString` in the `JavaToSqlTypeConversionRules` class. This PR adds the necessary mapping.