### PR TITLE
Preserve ARRAY subquery type with ORDER BY

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -5645,7 +5645,14 @@ public class SqlToRelConverter {
           // let top=true to make the query be top-level query,
           // then ORDER BY will be reserved.
           root = convertQueryRecursive(query, true, null);
-          return RexSubQuery.array(root.rel);
+          // ORDER BY expressions may add internal fields to the relational
+          // expression. ARRAY must contain only the query's selected fields.
+          final RelNode arrayInput = query instanceof SqlSelect
+              ? RelOptUtil.createProject(root.rel,
+                  ImmutableIntList.range(0,
+                      ((SqlSelect) query).getSelectList().size()))
+              : root.project(true);
+          return RexSubQuery.array(arrayInput);
 
         case MAP_QUERY_CONSTRUCTOR:
           call = (SqlCall) expr;

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -5647,11 +5647,14 @@ public class SqlToRelConverter {
           root = convertQueryRecursive(query, true, null);
           // ORDER BY expressions may add internal fields to the relational
           // expression. ARRAY must contain only the query's selected fields.
-          final RelNode arrayInput = query instanceof SqlSelect
+          final int selectedFieldCount = query instanceof SqlSelect
+              ? ((SqlSelect) query).getSelectList().size()
+              : root.rel.getRowType().getFieldCount();
+          final RelNode arrayInput = root.rel.getRowType().getFieldCount()
+              > selectedFieldCount
               ? RelOptUtil.createProject(root.rel,
-                  ImmutableIntList.range(0,
-                      ((SqlSelect) query).getSelectList().size()))
-              : root.project(true);
+                  ImmutableIntList.range(0, selectedFieldCount))
+              : root.rel;
           return RexSubQuery.array(arrayInput);
 
         case MAP_QUERY_CONSTRUCTOR:

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableUncollectTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableUncollectTest.java
@@ -34,6 +34,28 @@ class EnumerableUncollectTest {
             "y=4");
   }
 
+  @Test void arraySubQueryPreservesUnnestOrder() {
+    final String sql = "select a as source_array,"
+        + " array(select y from unnest(a) as u(y)) as transformed_array,"
+        + " ARRAY_DISTINCT(array(select y from unnest(a) as u(y))) as distinct_array"
+        + " from (values (array[cast('analytics_pixel_tag_helper' as varchar),"
+        + " cast('ad_blocker' as varchar), cast('randomized_extension' as varchar)])) as t(a)";
+    tester()
+        .with(CalciteConnectionProperty.FUN, "spark")
+        .query(sql)
+        .returns("source_array=[analytics_pixel_tag_helper, ad_blocker, randomized_extension]; "
+            + "transformed_array=[analytics_pixel_tag_helper, ad_blocker, randomized_extension]; "
+            + "distinct_array=[analytics_pixel_tag_helper, ad_blocker, randomized_extension]\n");
+  }
+
+  @Test void orderedArraySubQueryWithOrdinality() {
+    final String sql = "select array(select y from unnest(a) with ordinality as u(y, o) order by o)"
+        + " from (values (array[cast('a' as varchar), cast('b' as varchar)])) as t(a)";
+    tester()
+        .query(sql)
+        .returns("EXPR$0=[a, b]\n");
+  }
+
   @Test void simpleUnnestNullArray() {
     final String sql = "SELECT * FROM UNNEST(CAST(null AS INTEGER ARRAY))";
     tester()

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7760,7 +7760,7 @@ LogicalDelta
     </Resource>
     <Resource name="plan">
       <![CDATA[
-LogicalProject(EXPR$0=[AND(=(1, CAST('y'):INTEGER NOT NULL), =(CAST('x'):INTEGER NOT NULL, 1))])
+LogicalProject(EXPR$0=[AND(=(1, 'y'), =('x', 1))])
   LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>


### PR DESCRIPTION
## Summary
- project ARRAY subqueries back to their selected fields after preserving ORDER BY expressions
- prevent hidden ordering columns from becoming part of the array element type
- add regression coverage for ordered UNNEST/ARRAY subqueries and ARRAY_DISTINCT ordering

## Context
Calcite preserves ORDER BY expressions as internal fields while converting an ARRAY query. Those fields were passed directly to `RexSubQuery.array`, causing an expression such as `ARRAY(SELECT value ... ORDER BY ordinal)` to be converted as an array of `(value, ordinal)` rows instead of an array of values.

## Validation
```
./gradlew :core:test --tests org.apache.calcite.test.enumerable.EnumerableUncollectTest --no-daemon
```

Result: 19 tests completed, 0 failed.